### PR TITLE
udpated apis to grab data by 'sensor_type' property instead of 'sensror'

### DIFF
--- a/knex/migrations/20250408001521_blankData1.js
+++ b/knex/migrations/20250408001521_blankData1.js
@@ -9,7 +9,7 @@ exports.up = function (knex) {
     return knex.schema.createTable("BlankData1", (table) => {
       table.increments("id").primary();
       table.string("date").notNullable();
-      table.string("sensor").notNullable();
+      table.string("sensor_type").notNullable();
       table.decimal("value").notNullable();
     });
   };

--- a/knex/migrations/20250408004808_blankData2.js
+++ b/knex/migrations/20250408004808_blankData2.js
@@ -9,7 +9,7 @@ exports.up = function (knex) {
     return knex.schema.createTable("BlankData2", (table) => {
       table.increments("id").primary();
       table.string("date").notNullable();
-      table.string("sensor").notNullable();
+      table.string("sensor_type").notNullable();
       table.decimal("value").notNullable();
     });
   };

--- a/knex/migrations/20250408004814_blankData3.js
+++ b/knex/migrations/20250408004814_blankData3.js
@@ -9,7 +9,7 @@ exports.up = function (knex) {
     return knex.schema.createTable("BlankData3", (table) => {
       table.increments("id").primary();
       table.string("date").notNullable();
-      table.string("sensor").notNullable();
+      table.string("sensor_type").notNullable();
       table.decimal("value").notNullable();
     });
   };

--- a/models/BlankData1.js
+++ b/models/BlankData1.js
@@ -17,7 +17,7 @@ export default class BlankData1 extends BaseModel {
       properties: {
         id: { type: "integer" },
         date: { type: "string" },
-        sensor: { type: "string" },
+        sensor_type: { type: "string" },
         value: { type: "number"},
       },
     };

--- a/models/BlankData2.js
+++ b/models/BlankData2.js
@@ -17,7 +17,7 @@ export default class BlankData2 extends BaseModel {
       properties: {
         id: { type: "integer" },
         date: { type: "string" },
-        sensor: { type: "string" },
+        sensor_type: { type: "string" },
         value: { type: "number"},
       },
     };

--- a/models/BlankData3.js
+++ b/models/BlankData3.js
@@ -17,7 +17,7 @@ export default class BlankData3 extends BaseModel {
       properties: {
         id: { type: "integer" },
         date: { type: "string" },
-        sensor: { type: "string" },
+        sensor_type: { type: "string" },
         value: { type: "number"},
       },
     };

--- a/src/app/api/blankData1/route.js
+++ b/src/app/api/blankData1/route.js
@@ -18,7 +18,7 @@ export async function GET(request){
     lastSundayDate.setDate(currentDate.getDate() - offsetToLastSunday);
     lastSundayDate = normalizeToLocalMidnight(lastSundayDate);
     try {
-        const blankData1 = await BlankData1.query().orderBy('sensor', 'asc');
+        const blankData1 = await BlankData1.query().orderBy('sensor_type', 'asc');
         if (blankData1) {
           const weekData = blankData1.filter((input) => {
             const inputDate = normalizeToLocalMidnight(new Date(input.date));
@@ -26,15 +26,15 @@ export async function GET(request){
          })
          if (weekData.length > 0 && sorted){
           const groupedData = [];
-          let current = weekData[0].sensor;
+          let current = weekData[0].sensor_type;
           let currentArray = [];
           weekData.forEach((element) => {
-            if (element.sensor === current){
+            if (element.sensor_type === current){
               currentArray.push(element);
             }else{
               groupedData.push(currentArray);
               currentArray = [element];
-              current = element.sensor;
+              current = element.sensor_type;
             }
           })
           groupedData.push(currentArray);

--- a/src/app/api/blankData2/route.js
+++ b/src/app/api/blankData2/route.js
@@ -18,7 +18,7 @@ export async function GET(request){
     lastSundayDate.setDate(currentDate.getDate() - offsetToLastSunday);
     lastSundayDate = normalizeToLocalMidnight(lastSundayDate);
     try {
-        const blankData2 = await BlankData2.query().orderBy('sensor', 'asc');
+        const blankData2 = await BlankData2.query().orderBy('sensor_type', 'asc');
         if (blankData2) {
           const weekData = blankData2.filter((input) => {
             const inputDate = normalizeToLocalMidnight(new Date(input.date));
@@ -26,15 +26,15 @@ export async function GET(request){
          })
          if (weekData.length > 0 && sorted){
           const groupedData = [];
-          let current = weekData[0].sensor;
+          let current = weekData[0].sensor_type;
           let currentArray = [];
           weekData.forEach((element) => {
-            if (element.sensor === current){
+            if (element.sensor_type === current){
               currentArray.push(element);
             }else{
               groupedData.push(currentArray);
               currentArray = [element];
-              current = element.sensor;
+              current = element.sensor_type;
             }
           })
           groupedData.push(currentArray);

--- a/src/app/api/blankData3/route.js
+++ b/src/app/api/blankData3/route.js
@@ -18,7 +18,7 @@ export async function GET(request){
     lastSundayDate.setDate(currentDate.getDate() - offsetToLastSunday);
     lastSundayDate = normalizeToLocalMidnight(lastSundayDate);
     try {
-        const blankData3 = await BlankData3.query().orderBy('sensor', 'asc');
+        const blankData3 = await BlankData3.query().orderBy('sensor_type', 'asc');
         if (blankData3) {
           const weekData = blankData3.filter((input) => {
             const inputDate = normalizeToLocalMidnight(new Date(input.date));
@@ -26,15 +26,15 @@ export async function GET(request){
          })
          if (weekData.length > 0 && sorted){
           const groupedData = [];
-          let current = weekData[0].sensor;
+          let current = weekData[0].sensor_type;
           let currentArray = [];
           weekData.forEach((element) => {
-            if (element.sensor === current){
+            if (element.sensor_type === current){
               currentArray.push(element);
             }else{
               groupedData.push(currentArray);
               currentArray = [element];
-              current = element.sensor;
+              current = element.sensor_type;
             }
           })
           groupedData.push(currentArray);

--- a/src/app/api/nutritionData/route.js
+++ b/src/app/api/nutritionData/route.js
@@ -27,7 +27,7 @@ export async function GET(request){
     const threeDaysAgo = normalizeToLocalMidnight(new Date(currentDate.toLocaleDateString()));
     threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
     try {
-        const nutrition = await Nutrition.query().orderBy('sensor', 'asc');
+        const nutrition = await Nutrition.query().orderBy('sensor_type', 'asc');
         if (nutrition) {
           const weekData = nutrition.filter((input) => {
             const inputDate = normalizeToLocalMidnight(new Date(input.date));
@@ -35,15 +35,15 @@ export async function GET(request){
           })
           if (weekData.length > 0 && sorted){
             const groupedData = [];
-            let current = weekData[0].sensor;
+            let current = weekData[0].sensor_type;
             let currentArray = [];
             weekData.forEach((element) => {
-              if (element.sensor === current){
+              if (element.sensor_type === current){
                 currentArray.push(element);
               }else{
                 groupedData.push(currentArray);
                 currentArray = [element];
-                current = element.sensor;
+                current = element.sensor_type;
               }
             })
             groupedData.push(currentArray);

--- a/src/app/api/pHData/route.js
+++ b/src/app/api/pHData/route.js
@@ -26,7 +26,7 @@ export async function GET(request){
     const threeDaysAgo = normalizeToLocalMidnight(new Date(currentDate.toLocaleDateString()));
     threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
     try {
-        const ph = await PH.query().orderBy('sensor', 'asc');
+        const ph = await PH.query().orderBy('sensor_type', 'asc');
         if (ph) {
           const weekData = ph.filter((input) => {
             const inputDate = normalizeToLocalMidnight(new Date(input.date));
@@ -34,15 +34,15 @@ export async function GET(request){
          })
          if (weekData.length > 0 && sorted){
           const groupedData = [];
-          let current = weekData[0].sensor;
+          let current = weekData[0].sensor_type;
           let currentArray = [];
           weekData.forEach((element) => {
-            if (element.sensor === current){
+            if (element.sensor_type === current){
               currentArray.push(element);
             }else{
               groupedData.push(currentArray);
               currentArray = [element];
-              current = element.sensor;
+              current = element.sensor_type;
             }
           })
           groupedData.push(currentArray);

--- a/src/app/nutritionData/page.js
+++ b/src/app/nutritionData/page.js
@@ -15,7 +15,7 @@ export default function NutritionData() {
         fetch(`/api/nutritionData?sorted=true`)
             .then(response => {
                 if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
+                    throw new Error(`HTTP error! status: ${response.status}`);
                 }
                 return response.json();
             })

--- a/src/app/pHData/page.js
+++ b/src/app/pHData/page.js
@@ -15,7 +15,7 @@ export default function PHData() {
         fetch(`/api/pHData?sorted=true`)
             .then(response => {
                 if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
+                    throw new Error(`HTTP error! status: ${response.status}`);
                 }
                 return response.json();
             })


### PR DESCRIPTION
- because column name was changed, api needs to reference 'sensor_type' property not 'sensor' property of returned json
- current API endpoints/GET handlers are setup to batch data from multiple sensors of the same type (e.g. 'Ph1', 'Ph2', ...). Because we are only using one of each sensor this is redundant but a possible piece of functionality we can use later